### PR TITLE
[Fix] : fixed-size load for Neon to RVV

### DIFF
--- a/simde/arm/neon/ld1.h
+++ b/simde/arm/neon/ld1.h
@@ -41,7 +41,7 @@ simde_vld1_f16(simde_float16 const ptr[HEDLEY_ARRAY_PARAM(4)]) {
     return vld1_f16(ptr);
   #else
     simde_float16x4_private r_;
-    simde_memcpy(&r_, ptr, sizeof(r_));
+    simde_memcpy(&r_, ptr, 8);
     return simde_float16x4_from_private(r_);
   #endif
 }
@@ -57,7 +57,7 @@ simde_vld1_f32(simde_float32 const ptr[HEDLEY_ARRAY_PARAM(2)]) {
     return vld1_f32(ptr);
   #else
     simde_float32x2_private r_;
-    simde_memcpy(&r_, ptr, sizeof(r_));
+    simde_memcpy(&r_, ptr, 8);
     return simde_float32x2_from_private(r_);
   #endif
 }
@@ -73,7 +73,7 @@ simde_vld1_f64(simde_float64 const ptr[HEDLEY_ARRAY_PARAM(1)]) {
     return vld1_f64(ptr);
   #else
     simde_float64x1_private r_;
-    simde_memcpy(&r_, ptr, sizeof(r_));
+    simde_memcpy(&r_, ptr, 8);
     return simde_float64x1_from_private(r_);
   #endif
 }
@@ -89,7 +89,7 @@ simde_vld1_s8(int8_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
     return vld1_s8(ptr);
   #else
     simde_int8x8_private r_;
-    simde_memcpy(&r_, ptr, sizeof(r_));
+    simde_memcpy(&r_, ptr, 8);
     return simde_int8x8_from_private(r_);
   #endif
 }
@@ -105,7 +105,7 @@ simde_vld1_s16(int16_t const ptr[HEDLEY_ARRAY_PARAM(4)]) {
     return vld1_s16(ptr);
   #else
     simde_int16x4_private r_;
-    simde_memcpy(&r_, ptr, sizeof(r_));
+    simde_memcpy(&r_, ptr, 8);
     return simde_int16x4_from_private(r_);
   #endif
 }
@@ -121,7 +121,7 @@ simde_vld1_s32(int32_t const ptr[HEDLEY_ARRAY_PARAM(2)]) {
     return vld1_s32(ptr);
   #else
     simde_int32x2_private r_;
-    simde_memcpy(&r_, ptr, sizeof(r_));
+    simde_memcpy(&r_, ptr, 8);
     return simde_int32x2_from_private(r_);
   #endif
 }
@@ -137,7 +137,7 @@ simde_vld1_s64(int64_t const ptr[HEDLEY_ARRAY_PARAM(1)]) {
     return vld1_s64(ptr);
   #else
     simde_int64x1_private r_;
-    simde_memcpy(&r_, ptr, sizeof(r_));
+    simde_memcpy(&r_, ptr, 8);
     return simde_int64x1_from_private(r_);
   #endif
 }
@@ -153,7 +153,7 @@ simde_vld1_u8(uint8_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
     return vld1_u8(ptr);
   #else
     simde_uint8x8_private r_;
-    simde_memcpy(&r_, ptr, sizeof(r_));
+    simde_memcpy(&r_, ptr, 8);
     return simde_uint8x8_from_private(r_);
   #endif
 }
@@ -169,7 +169,7 @@ simde_vld1_u16(uint16_t const ptr[HEDLEY_ARRAY_PARAM(4)]) {
     return vld1_u16(ptr);
   #else
     simde_uint16x4_private r_;
-    simde_memcpy(&r_, ptr, sizeof(r_));
+    simde_memcpy(&r_, ptr, 8);
     return simde_uint16x4_from_private(r_);
   #endif
 }
@@ -185,7 +185,7 @@ simde_vld1_u32(uint32_t const ptr[HEDLEY_ARRAY_PARAM(2)]) {
     return vld1_u32(ptr);
   #else
     simde_uint32x2_private r_;
-    simde_memcpy(&r_, ptr, sizeof(r_));
+    simde_memcpy(&r_, ptr, 8);
     return simde_uint32x2_from_private(r_);
   #endif
 }
@@ -201,7 +201,7 @@ simde_vld1_u64(uint64_t const ptr[HEDLEY_ARRAY_PARAM(1)]) {
     return vld1_u64(ptr);
   #else
     simde_uint64x1_private r_;
-    simde_memcpy(&r_, ptr, sizeof(r_));
+    simde_memcpy(&r_, ptr, 8);
     return simde_uint64x1_from_private(r_);
   #endif
 }
@@ -220,7 +220,7 @@ simde_vld1q_f16(simde_float16 const ptr[HEDLEY_ARRAY_PARAM(8)]) {
     #if defined(SIMDE_WASM_SIMD128_NATIVE)
       r_.v128 = wasm_v128_load(ptr);
     #else
-      simde_memcpy(&r_, ptr, sizeof(r_));
+      simde_memcpy(&r_, ptr, 16);
     #endif
     return simde_float16x8_from_private(r_);
   #endif
@@ -240,7 +240,7 @@ simde_vld1q_f32(simde_float32 const ptr[HEDLEY_ARRAY_PARAM(4)]) {
     #if defined(SIMDE_WASM_SIMD128_NATIVE)
       r_.v128 = wasm_v128_load(ptr);
     #else
-      simde_memcpy(&r_, ptr, sizeof(r_));
+      simde_memcpy(&r_, ptr, 16);
     #endif
     return simde_float32x4_from_private(r_);
   #endif
@@ -260,7 +260,7 @@ simde_vld1q_f64(simde_float64 const ptr[HEDLEY_ARRAY_PARAM(2)]) {
     #if defined(SIMDE_WASM_SIMD128_NATIVE)
       r_.v128 = wasm_v128_load(ptr);
     #else
-      simde_memcpy(&r_, ptr, sizeof(r_));
+      simde_memcpy(&r_, ptr, 16);
     #endif
     return simde_float64x2_from_private(r_);
   #endif
@@ -280,7 +280,7 @@ simde_vld1q_s8(int8_t const ptr[HEDLEY_ARRAY_PARAM(16)]) {
     #if defined(SIMDE_WASM_SIMD128_NATIVE)
       r_.v128 = wasm_v128_load(ptr);
     #else
-      simde_memcpy(&r_, ptr, sizeof(r_));
+      simde_memcpy(&r_, ptr, 16);
     #endif
     return simde_int8x16_from_private(r_);
   #endif
@@ -300,7 +300,7 @@ simde_vld1q_s16(int16_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
     #if defined(SIMDE_WASM_SIMD128_NATIVE)
       r_.v128 = wasm_v128_load(ptr);
     #else
-      simde_memcpy(&r_, ptr, sizeof(r_));
+      simde_memcpy(&r_, ptr, 16);
     #endif
     return simde_int16x8_from_private(r_);
   #endif
@@ -320,7 +320,7 @@ simde_vld1q_s32(int32_t const ptr[HEDLEY_ARRAY_PARAM(4)]) {
     #if defined(SIMDE_WASM_SIMD128_NATIVE)
       r_.v128 = wasm_v128_load(ptr);
     #else
-      simde_memcpy(&r_, ptr, sizeof(r_));
+      simde_memcpy(&r_, ptr, 16);
     #endif
     return simde_int32x4_from_private(r_);
   #endif
@@ -340,7 +340,7 @@ simde_vld1q_s64(int64_t const ptr[HEDLEY_ARRAY_PARAM(2)]) {
     #if defined(SIMDE_WASM_SIMD128_NATIVE)
       r_.v128 = wasm_v128_load(ptr);
     #else
-      simde_memcpy(&r_, ptr, sizeof(r_));
+      simde_memcpy(&r_, ptr, 16);
     #endif
     return simde_int64x2_from_private(r_);
   #endif
@@ -360,7 +360,7 @@ simde_vld1q_u8(uint8_t const ptr[HEDLEY_ARRAY_PARAM(16)]) {
     #if defined(SIMDE_WASM_SIMD128_NATIVE)
       r_.v128 = wasm_v128_load(ptr);
     #else
-      simde_memcpy(&r_, ptr, sizeof(r_));
+      simde_memcpy(&r_, ptr, 16);
     #endif
     return simde_uint8x16_from_private(r_);
   #endif
@@ -380,7 +380,7 @@ simde_vld1q_u16(uint16_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
     #if defined(SIMDE_WASM_SIMD128_NATIVE)
       r_.v128 = wasm_v128_load(ptr);
     #else
-      simde_memcpy(&r_, ptr, sizeof(r_));
+      simde_memcpy(&r_, ptr, 16);
     #endif
     return simde_uint16x8_from_private(r_);
   #endif
@@ -400,7 +400,7 @@ simde_vld1q_u32(uint32_t const ptr[HEDLEY_ARRAY_PARAM(4)]) {
     #if defined(SIMDE_WASM_SIMD128_NATIVE)
       r_.v128 = wasm_v128_load(ptr);
     #else
-      simde_memcpy(&r_, ptr, sizeof(r_));
+      simde_memcpy(&r_, ptr, 16);
     #endif
     return simde_uint32x4_from_private(r_);
   #endif
@@ -420,7 +420,7 @@ simde_vld1q_u64(uint64_t const ptr[HEDLEY_ARRAY_PARAM(2)]) {
     #if defined(SIMDE_WASM_SIMD128_NATIVE)
       r_.v128 = wasm_v128_load(ptr);
     #else
-      simde_memcpy(&r_, ptr, sizeof(r_));
+      simde_memcpy(&r_, ptr, 16);
     #endif
     return simde_uint64x2_from_private(r_);
   #endif

--- a/simde/arm/neon/ld2.h
+++ b/simde/arm/neon/ld2.h
@@ -62,7 +62,7 @@ simde_vld2_s8(int8_t const ptr[HEDLEY_ARRAY_PARAM(16)]) {
     simde_int8x16_private a_ = simde_int8x16_to_private(simde_vld1q_s8(ptr));
     a_.values = SIMDE_SHUFFLE_VECTOR_(8, 16, a_.values, a_.values, 0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13, 15);
     simde_int8x8x2_t r;
-    simde_memcpy(&r, &a_, sizeof(r));
+    simde_memcpy(&r, &a_, 16);
     return r;
   #else
     simde_int8x8_private r_[2];
@@ -95,7 +95,7 @@ simde_vld2_s16(int16_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
     simde_int16x8_private a_ = simde_int16x8_to_private(simde_vld1q_s16(ptr));
     a_.values = SIMDE_SHUFFLE_VECTOR_(16, 16, a_.values, a_.values, 0, 2, 4, 6, 1, 3, 5, 7);
     simde_int16x4x2_t r;
-    simde_memcpy(&r, &a_, sizeof(r));
+    simde_memcpy(&r, &a_, 16);
     return r;
   #else
     #if defined(SIMDE_DIAGNOSTIC_DISABLE_UNINITIALIZED_) && HEDLEY_GCC_VERSION_CHECK(12,0,0)
@@ -135,7 +135,7 @@ simde_vld2_s32(int32_t const ptr[HEDLEY_ARRAY_PARAM(4)]) {
     simde_int32x4_private a_ = simde_int32x4_to_private(simde_vld1q_s32(ptr));
     a_.values = SIMDE_SHUFFLE_VECTOR_(32, 16, a_.values, a_.values, 0, 2, 1, 3);
     simde_int32x2x2_t r;
-    simde_memcpy(&r, &a_, sizeof(r));
+    simde_memcpy(&r, &a_, 16);
     return r;
   #else
     simde_int32x2_private r_[2];
@@ -168,7 +168,7 @@ simde_vld2_s64(int64_t const ptr[HEDLEY_ARRAY_PARAM(2)]) {
     simde_int64x2_private a_ = simde_int64x2_to_private(simde_vld1q_s64(ptr));
     a_.values = SIMDE_SHUFFLE_VECTOR_(64, 16, a_.values, a_.values, 0, 1);
     simde_int64x1x2_t r;
-    simde_memcpy(&r, &a_, sizeof(r));
+    simde_memcpy(&r, &a_, 16);
     return r;
   #else
     simde_int64x1_private r_[2];
@@ -212,7 +212,7 @@ simde_vld2_u8(uint8_t const ptr[HEDLEY_ARRAY_PARAM(16)]) {
     simde_uint8x16_private a_ = simde_uint8x16_to_private(simde_vld1q_u8(ptr));
     a_.values = SIMDE_SHUFFLE_VECTOR_(8, 16, a_.values, a_.values, 0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13, 15);
     simde_uint8x8x2_t r;
-    simde_memcpy(&r, &a_, sizeof(r));
+    simde_memcpy(&r, &a_, 16);
     return r;
   #else
     simde_uint8x8_private r_[2];
@@ -245,7 +245,7 @@ simde_vld2_u16(uint16_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
     simde_uint16x8_private a_ = simde_uint16x8_to_private(simde_vld1q_u16(ptr));
     a_.values = SIMDE_SHUFFLE_VECTOR_(16, 16, a_.values, a_.values, 0, 2, 4, 6, 1, 3, 5, 7);
     simde_uint16x4x2_t r;
-    simde_memcpy(&r, &a_, sizeof(r));
+    simde_memcpy(&r, &a_, 16);
     return r;
   #else
     #if defined(SIMDE_DIAGNOSTIC_DISABLE_UNINITIALIZED_) && HEDLEY_GCC_VERSION_CHECK(12,0,0)
@@ -285,7 +285,7 @@ simde_vld2_u32(uint32_t const ptr[HEDLEY_ARRAY_PARAM(4)]) {
     simde_uint32x4_private a_ = simde_uint32x4_to_private(simde_vld1q_u32(ptr));
     a_.values = SIMDE_SHUFFLE_VECTOR_(32, 16, a_.values, a_.values, 0, 2, 1, 3);
     simde_uint32x2x2_t r;
-    simde_memcpy(&r, &a_, sizeof(r));
+    simde_memcpy(&r, &a_, 16);
     return r;
   #else
     simde_uint32x2_private r_[2];
@@ -318,7 +318,7 @@ simde_vld2_u64(uint64_t const ptr[HEDLEY_ARRAY_PARAM(2)]) {
     simde_uint64x2_private a_ = simde_uint64x2_to_private(simde_vld1q_u64(ptr));
     a_.values = SIMDE_SHUFFLE_VECTOR_(64, 16, a_.values, a_.values, 0, 1);
     simde_uint64x1x2_t r;
-    simde_memcpy(&r, &a_, sizeof(r));
+    simde_memcpy(&r, &a_, 16);
     return r;
   #else
     simde_uint64x1_private r_[2];
@@ -378,7 +378,7 @@ simde_vld2_f32(simde_float32_t const ptr[HEDLEY_ARRAY_PARAM(4)]) {
     simde_float32x4_private a_ = simde_float32x4_to_private(simde_vld1q_f32(ptr));
     a_.values = SIMDE_SHUFFLE_VECTOR_(32, 16, a_.values, a_.values, 0, 2, 1, 3);
     simde_float32x2x2_t r;
-    simde_memcpy(&r, &a_, sizeof(r));
+    simde_memcpy(&r, &a_, 16);
     return r;
   #else
     simde_float32x2_private r_[2];
@@ -411,7 +411,7 @@ simde_vld2_f64(simde_float64_t const ptr[HEDLEY_ARRAY_PARAM(2)]) {
     simde_float64x2_private a_ = simde_float64x2_to_private(simde_vld1q_f64(ptr));
     a_.values = SIMDE_SHUFFLE_VECTOR_(64, 16, a_.values, a_.values, 0, 1);
     simde_float64x1x2_t r;
-    simde_memcpy(&r, &a_, sizeof(r));
+    simde_memcpy(&r, &a_, 16);
     return r;
   #else
     simde_float64x1_private r_[2];


### PR DESCRIPTION
The vector lengths of RVV and Neon may differ, so copying sizeof(union) of bytes from one memory location to another may pollute memory. Currently, instructions that may lead to this error include: ld1.h, ld2.h.